### PR TITLE
Fix/Puzzle 오브젝트 구분 및 기타 버그 수정

### DIFF
--- a/CODE_PANDEMIC/Assets/@Resources/Data/PuzzleData.json
+++ b/CODE_PANDEMIC/Assets/@Resources/Data/PuzzleData.json
@@ -12,7 +12,8 @@
         "y": 85.21,
         "z": 0
       },
-      "IsMain": false
+      "IsMain": false,
+      "RememberCount": 5
     },
     {
 
@@ -59,7 +60,8 @@
           "z": 0
         },
         "IsMain": false,
-        "IsClear": false
+        "IsClear": false,
+        "RememberCount": 6
       },
     {
       "ID": 4,
@@ -70,8 +72,8 @@
         "Quantity": 0
       },
       "Pos": {
-        "x": 349.94,
-        "y": 80.4,
+        "x": 363.37,
+        "y": 92.05,
         "z": 0
       },
       "IsMain": true,
@@ -136,7 +138,8 @@
           "z": 0
         },
         "IsMain": false,
-        "IsClear": false
+        "IsClear": false,
+        "RememberCount": 7
       },
     {
       "ID": 7,

--- a/CODE_PANDEMIC/Assets/Scenes/TestPuzzleScene.unity
+++ b/CODE_PANDEMIC/Assets/Scenes/TestPuzzleScene.unity
@@ -235,11 +235,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1133950236140605570, guid: 074abb09c3b08d8438bd818e6c654d6f, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 396.17
+      value: 363.37
       objectReference: {fileID: 0}
     - target: {fileID: 1133950236140605570, guid: 074abb09c3b08d8438bd818e6c654d6f, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 69.22
+      value: 91.05
       objectReference: {fileID: 0}
     - target: {fileID: 1133950236140605570, guid: 074abb09c3b08d8438bd818e6c654d6f, type: 3}
       propertyPath: m_LocalPosition.z

--- a/CODE_PANDEMIC/Assets/Scripts/Data/DataLoader.cs
+++ b/CODE_PANDEMIC/Assets/Scripts/Data/DataLoader.cs
@@ -250,7 +250,8 @@ public class PuzzleData
     public RewardData RewardItem;
     public Vector3 Pos;
     public bool IsMain;
-    public BlockData LinkedBlock;   
+    public BlockData LinkedBlock;
+    public int RememberCount;
 }    
 
 [Serializable]

--- a/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/Bed/PZ_Bed_Sliding.cs
+++ b/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/Bed/PZ_Bed_Sliding.cs
@@ -1,7 +1,7 @@
 ﻿using UnityEngine;
 using System.Collections;
 
-public class PZ_Bed_Sliding : PZ_Interact_Base
+public class PZ_Bed_Sliding : PZ_Interact_NonSpawn
 {
     public override void Interact(GameObject player)
     {

--- a/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/Bed/PZ_Interact_Bed.cs
+++ b/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/Bed/PZ_Interact_Bed.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-public class PZ_Interact_Bed : PZ_Interact_Base
+public class PZ_Interact_Bed : PZ_Interact_NonSpawn
 {
     // 침대 상호 작용
     public override void Interact(GameObject player)

--- a/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/BloodPack/PZ_BloodPack_Hanger.cs
+++ b/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/BloodPack/PZ_BloodPack_Hanger.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-public class PZ_BloodPack_Hanger : PZ_Interact_Base
+public class PZ_BloodPack_Hanger : PZ_Interact_NonSpawn
 {
     [SerializeField] private Sprite _interactedSprite;
 

--- a/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/Debris/PZ_Debris.cs
+++ b/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/Debris/PZ_Debris.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-public class PZ_Debris : PZ_Interact_Base
+public class PZ_Debris : PZ_Interact_NonSpawn
 {
     public override void Interact(GameObject player)
     {

--- a/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/Elevator/PZ_Elevator.cs
+++ b/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/Elevator/PZ_Elevator.cs
@@ -7,7 +7,7 @@ public enum ElevatingMap
     Hospital1
 }
 
-public class PZ_Elevator : PZ_Interact_Base
+public class PZ_Elevator : PZ_Interact_NonSpawn
 {
     [SerializeField] private ElevatingMap _currentMap; // 현재 맵
     [SerializeField] private ElevatingMap _elevatingMap; // 해당 엘레베이터로 이동할 맵
@@ -33,25 +33,12 @@ public class PZ_Elevator : PZ_Interact_Base
         base.Interact(player);
 
         _animator.SetBool("IsOpened", true);
-
-        // 여기에 다음 맵으로 넘어가는 기능 구현
-        //switch (_elevatingMap)
-        //{
-        //    case ElevatingMap.Hospital3:
-        //        Debug.Log("3층 이동");
-        //        break;
-
-        //    case ElevatingMap.Hospital2:
-        //        Debug.Log("2층 이동");
-        //        break;
-
-        //    case ElevatingMap.Hospital1:
-        //        Debug.Log("1층 이동");
-        //        break;
-        //}
+        
         Managers.Event.InvokeEvent("NextStage");
+
         _elevatorScreen.Setting(_elevatingMap);
     }
+
     private void UpdateStage()
     {
 

--- a/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/Fire Extinguisher/PZ_FireExtinguisher.cs
+++ b/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/Fire Extinguisher/PZ_FireExtinguisher.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-public class PZ_FireExtinguisher : PZ_Interact_Base
+public class PZ_FireExtinguisher : PZ_Interact_NonSpawn
 {
     [SerializeField] private Rigidbody2D _rigidbody;
 

--- a/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/Generator/PZ_Generator.cs
+++ b/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/Generator/PZ_Generator.cs
@@ -15,6 +15,11 @@ public class PZ_Generator : PZ_Puzzle_Base, IInteractable
     [SerializeField] private Material _defaultMaterial;
     [SerializeField] private Material _highlightMaterial;
 
+    public void SetInfo(PuzzleData data)
+    {
+        _rememberCount = data.RememberCount;
+    }
+
     private void Start()
     {
         _animator = GetComponentInChildren<Animator>();
@@ -27,8 +32,6 @@ public class PZ_Generator : PZ_Puzzle_Base, IInteractable
         {
             return;
         }
-
-        _isInteracted = true;
 
         Managers.UI.ShowPopupUI<PZ_Remember_Board>("PZ_Remember_Board_Prefab", null, (popupPuzzle) =>
         {
@@ -57,6 +60,8 @@ public class PZ_Generator : PZ_Puzzle_Base, IInteractable
         StartCoroutine(SettingLeverPosition());
 
         _animator.SetBool("IsInteracted", true);
+
+        _isInteracted = true;
 
         // 여기에 맵의 그림자를 걷어내는 로직 구현 예정
     }

--- a/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/HealPack/PZ_HealPack.cs
+++ b/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/HealPack/PZ_HealPack.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-public class PZ_HealPack : PZ_Interact_Base
+public class PZ_HealPack : PZ_Interact_Spawn
 {
     [SerializeField] private Sprite _interactedSprite;
 

--- a/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/Key & Safe/PZ_Key.cs
+++ b/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/Key & Safe/PZ_Key.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-public class PZ_Key : PZ_Interact_Base
+public class PZ_Key : PZ_Interact_Spawn
 {
     public override void Interact(GameObject player)
     {

--- a/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/Key & Safe/PZ_Safe.cs
+++ b/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/Key & Safe/PZ_Safe.cs
@@ -1,6 +1,6 @@
 ﻿using UnityEngine;
 
-public class PZ_Safe : PZ_Interact_Base
+public class PZ_Safe : PZ_Interact_Spawn
 {
     public bool _hasKey = false; // 열쇠로 열기
 

--- a/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/PZ_Interact_NonSpawn.cs
+++ b/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/PZ_Interact_NonSpawn.cs
@@ -1,0 +1,4 @@
+﻿public class PZ_Interact_NonSpawn : PZ_Interact_Base
+{
+   
+}

--- a/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/PZ_Interact_NonSpawn.cs.meta
+++ b/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/PZ_Interact_NonSpawn.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: fc127f1b56576b746b08df608e0c131d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/PZ_Interact_Spawn.cs
+++ b/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/PZ_Interact_Spawn.cs
@@ -1,0 +1,4 @@
+﻿public class PZ_Interact_Spawn : PZ_Interact_Base
+{
+    
+}

--- a/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/PZ_Interact_Spawn.cs.meta
+++ b/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/PZ_Interact_Spawn.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a162283fd90c4f245880485e4259bc3a
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/Poster/PZ_Poster.cs
+++ b/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/Poster/PZ_Poster.cs
@@ -1,7 +1,7 @@
 ﻿using UnityEngine;
 using System.Collections;
 
-public class PZ_Poster : PZ_Interact_Base
+public class PZ_Poster : PZ_Interact_NonSpawn
 {
     public override void Interact(GameObject player)
     {

--- a/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/Puzzle Item/PZ_Puzzle_Item.cs
+++ b/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/Puzzle Item/PZ_Puzzle_Item.cs
@@ -1,7 +1,7 @@
 ﻿using UnityEngine;
 using System.Collections;
 
-public class PZ_Puzzle_Item : PZ_Interact_Base
+public class PZ_Puzzle_Item : PZ_Interact_Spawn
 {
     #region Base
 

--- a/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/Puzzle Item/PZ_Puzzle_Item.cs
+++ b/CODE_PANDEMIC/Assets/Scripts/Puzzle/Interact/Puzzle Item/PZ_Puzzle_Item.cs
@@ -105,8 +105,10 @@ public class PZ_Puzzle_Item : PZ_Interact_Spawn
 
     public void ClearPuzzle()
     {
-       
         Managers.Object.UnregisterPuzzles();
+
+        Managers.UI.ClosePopupUI();
+
         if (_isMainPuzzle)
         {
             Managers.Event.InvokeEvent("MainPuzzleClear", this);

--- a/CODE_PANDEMIC/Assets/Scripts/Utils/Map/StageController.cs
+++ b/CODE_PANDEMIC/Assets/Scripts/Utils/Map/StageController.cs
@@ -1,4 +1,4 @@
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 
@@ -69,6 +69,7 @@ public class StageController : MonoBehaviour
             {
                 obj.transform.position = data.Pos;
                 PZ_Puzzle_Item puzzleItem = obj.GetComponent<PZ_Puzzle_Item>();
+                PZ_Generator generatorItem = obj.GetComponent<PZ_Generator>();
                 if (data.IsMain)
                 {
                     CreateBlock(data.ID,data.LinkedBlock);
@@ -77,6 +78,10 @@ public class StageController : MonoBehaviour
                 {
                     puzzleItem.SetInfo(data);
                     puzzleItem.SettingPuzzle();
+                }
+                else if (generatorItem != null)
+                {
+                    generatorItem.SetInfo(data);
                 }
 
             });


### PR DESCRIPTION
1. 스폰 오브젝트와 논스폰 오브젝트 구분
2. 발전기 퍼즐 ESC로 닫을 시 다시 열 수 없는 현상 수정
3. 2층 퍼즐 아이템 위치 데이터 수정
4. 발전기마다 암기해야하는 수 데이터 추가 및 연동